### PR TITLE
Adding 2 as a test case

### DIFF
--- a/spec/prime_spec.rb
+++ b/spec/prime_spec.rb
@@ -3,6 +3,7 @@ require_relative '../prime.rb'
 
 describe "prime?" do
   it 'returns true for prime numbers' do
+    expect(prime?(2)).to be(true)
     expect(prime?(3)).to be(true)
     expect(prime?(11)).to be(true)
     expect(prime?(105557)).to be(true)


### PR DESCRIPTION
I was writing the code for this lab when I noticed an error in the logic of my code. And I saw some people committing the same error looking at other's PR's.

Sometimes depending on the implementation someone will write:

```ruby
if number % 2 == 0
  return false
end
```

Problem is, 2 is divisible by 2 AND a prime number, so it would return `false` even if 2 count as prime number.

The test suite now can count with this test case. 
